### PR TITLE
cmd/bootkube: Allow config of generated manifests

### DIFF
--- a/cmd/bootkube/render.go
+++ b/cmd/bootkube/render.go
@@ -17,16 +17,20 @@ var (
 		RunE:    runCmdRender,
 	}
 
-	outDir string
+	outDir    string
+	assetConf asset.Config
 )
 
 func init() {
 	cmdRoot.AddCommand(cmdRender)
 	cmdRender.Flags().StringVar(&outDir, "outdir", "", "Output path for rendered manifests")
+	cmdRender.Flags().StringVar(&assetConf.APIServerCertIPAddrs, "apiserver-cert-ip-addrs", "", "IP Addresses to include in API Server cert SANs")
+	cmdRender.Flags().StringVar(&assetConf.ETCDServers, "etcd-servers", "", "List of etcd servers to contact")
+	cmdRender.Flags().StringVar(&assetConf.APIServers, "api-servers", "", "List of api servers to contact")
 }
 
 func runCmdRender(cmd *cobra.Command, args []string) error {
-	as, err := asset.NewDefaultAssets()
+	as, err := asset.NewDefaultAssets(assetConf)
 	if err != nil {
 		return err
 	}
@@ -36,6 +40,15 @@ func runCmdRender(cmd *cobra.Command, args []string) error {
 func validateRenderOpts(cmd *cobra.Command, args []string) error {
 	if outDir == "" {
 		return errors.New("Missing required flag: --outdir")
+	}
+	if assetConf.APIServerCertIPAddrs == "" {
+		return errors.New("Missing required flag: --apiserver-cert-ip-addrs")
+	}
+	if assetConf.APIServers == "" {
+		return errors.New("Missing required flag: --api-servers")
+	}
+	if assetConf.ETCDServers == "" {
+		return errors.New("Missing required flag: --etcd-servers")
 	}
 	return nil
 }

--- a/pkg/asset/k8s.go
+++ b/pkg/asset/k8s.go
@@ -20,14 +20,19 @@ const (
 func newStaticAssets() Assets {
 	var noData interface{}
 	return Assets{
-		mustCreateAssetFromTemplate(assetPathKubelet, internal.KubeletTemplate, noData),
-		mustCreateAssetFromTemplate(assetPathAPIServer, internal.APIServerTemplate, noData),
 		mustCreateAssetFromTemplate(assetPathControllerManager, internal.ControllerManagerTemplate, noData),
 		mustCreateAssetFromTemplate(assetPathScheduler, internal.SchedulerTemplate, noData),
-		mustCreateAssetFromTemplate(assetPathProxy, internal.ProxyTemplate, noData),
 		mustCreateAssetFromTemplate(assetPathKubeDNSRc, internal.DNSRcTemplate, noData),
 		mustCreateAssetFromTemplate(assetPathKubeDNSSvc, internal.DNSSvcTemplate, noData),
 		mustCreateAssetFromTemplate(assetPathSystemNamespace, internal.SystemNSTemplate, noData),
+	}
+}
+
+func newDynamicAssets(conf Config) Assets {
+	return Assets{
+		mustCreateAssetFromTemplate(assetPathKubelet, internal.KubeletTemplate, conf),
+		mustCreateAssetFromTemplate(assetPathAPIServer, internal.APIServerTemplate, conf),
+		mustCreateAssetFromTemplate(assetPathProxy, internal.ProxyTemplate, conf),
 	}
 }
 

--- a/pkg/asset/templates/kube-apiserver.yaml
+++ b/pkg/asset/templates/kube-apiserver.yaml
@@ -23,7 +23,7 @@ spec:
         - /hyperkube
         - apiserver
         - --bind-address=0.0.0.0
-        - --etcd-servers=http://127.0.0.1:2379
+        - --etcd-servers={{ .ETCDServers }}
         - --allow-privileged=true
         - --service-cluster-ip-range=10.3.0.0/24
         - --secure-port=6443

--- a/pkg/asset/templates/kube-proxy.yaml
+++ b/pkg/asset/templates/kube-proxy.yaml
@@ -22,7 +22,8 @@ spec:
         command:
         - /hyperkube
         - proxy
-        - --master=http://127.0.0.1:8080
+        - --master={{ .APIServers }}
+        - --kubeconfig=/etc/kubernetes/kubeconfig.yaml
         - --proxy-mode=iptables
         securityContext:
           privileged: true
@@ -30,7 +31,13 @@ spec:
         - mountPath: /etc/ssl/certs
           name: ssl-certs-host
           readOnly: true
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+          readOnly: true
       volumes:
       - hostPath:
           path: /usr/share/ca-certificates
         name: ssl-certs-host
+      - name: etc-kubernetes
+        hostPath:
+          path: /etc/kubernetes

--- a/pkg/asset/templates/kubelet.yaml
+++ b/pkg/asset/templates/kubelet.yaml
@@ -24,7 +24,7 @@ spec:
         - --
         - ./hyperkube
         - kubelet
-        - --api-servers=https://127.0.0.1:6443
+        - --api-servers={{ .APIServers }}
         - --allow-privileged
         - --cluster-dns=10.3.0.10
         - --cluster-domain=cluster.local

--- a/pkg/asset/tls.go
+++ b/pkg/asset/tls.go
@@ -7,7 +7,7 @@ import (
 	"github.com/coreos/bootkube/pkg/tlsutil"
 )
 
-func newTLSAssets() ([]Asset, error) {
+func newTLSAssets(apiCertIPs []string) ([]Asset, error) {
 	var assets []Asset
 
 	caKey, caCert, err := newCACert()
@@ -15,7 +15,7 @@ func newTLSAssets() ([]Asset, error) {
 		return assets, err
 	}
 
-	apiKey, apiCert, err := newAPIKeyAndCert(caCert, caKey)
+	apiKey, apiCert, err := newAPIKeyAndCert(caCert, caKey, apiCertIPs)
 	if err != nil {
 		return assets, err
 	}
@@ -60,7 +60,7 @@ func newCACert() (*rsa.PrivateKey, *x509.Certificate, error) {
 	return key, cert, err
 }
 
-func newAPIKeyAndCert(caCert *x509.Certificate, caKey *rsa.PrivateKey) (*rsa.PrivateKey, *x509.Certificate, error) {
+func newAPIKeyAndCert(caCert *x509.Certificate, caKey *rsa.PrivateKey, apiCertIPs []string) (*rsa.PrivateKey, *x509.Certificate, error) {
 	key, err := tlsutil.NewPrivateKey()
 	if err != nil {
 		return nil, nil, err
@@ -68,7 +68,7 @@ func newAPIKeyAndCert(caCert *x509.Certificate, caKey *rsa.PrivateKey) (*rsa.Pri
 	config := tlsutil.CertConfig{
 		CommonName:   "kube-apiserver",
 		Organization: []string{"kube-master"},
-		IPAddresses:  []string{"172.17.4.100", "127.0.0.1"}, //TODO(aaron): hack-placeholder
+		IPAddresses:  apiCertIPs,
 		DNSNames: []string{
 			"kubernetes",
 			"kubernetes.default",


### PR DESCRIPTION
This patch adds a few flags to configure the generated assets. We may
want to eventually move to something like configMaps or something in the
future, but for now this gets us enough configuration.