### PR TITLE
assets: remove nodeSelector on kube-proxy

### DIFF
--- a/pkg/asset/templates/kube-proxy.yaml
+++ b/pkg/asset/templates/kube-proxy.yaml
@@ -13,8 +13,6 @@ spec:
         k8s_app: kube-proxy
         version: v1.2.0_coreos.1
     spec:
-      nodeSelector:
-        master: "true"
       hostNetwork: true
       containers:
       - name: kube-proxy


### PR DESCRIPTION
The kube-proxy daemonset should not be limited to master nodes.