### PR TITLE
README: just use go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ When you start bootkube, you must also give it the addresses of your etcd server
 First, clone the repo into the proper location in your $GOPATH:
 
 ```
-git clone git@github.com:coreos/bootkube.git && cd bootkube
+go get -u github.com/coreos/bootkube
+cd $GOPATH/github.com/coreos/bootkube
 ```
 
 Then, to build:


### PR DESCRIPTION
Is there a reason for the added complexity of telling someone to clone into their GOPATH vs go getting? Seems like a left over from when this was a private repo.