### PR TITLE
hack: Update READMEs regarding auto-shutdown

### DIFF
--- a/hack/multi-node/README.md
+++ b/hack/multi-node/README.md
@@ -21,7 +21,7 @@ vagrant up
 ./bootkube-up
 ```
 
-Once kube-apiserver pod started, you can manually kill bootkube. After that, you will have a fully functional self-hosted multi-node cluster with cluster DNS.
+Once all components are running, bootkube will shut itself down. After that, you will have a fully functional self-hosted multi-node cluster with cluster DNS.
 
 ## Cleaning up
 

--- a/hack/single-node/README.md
+++ b/hack/single-node/README.md
@@ -21,7 +21,7 @@ vagrant up
 ./bootkube-up
 ```
 
-Once kube-apiserver pod started, you can manually kill bootkube. After that, you will have a fully functional single-node self-hosted cluster with cluster DNS.
+Once all components are running, bootkube will shut itself down. After that, you will have a fully functional single-node self-hosted cluster with cluster DNS.
 
 ## Cleaning up
 


### PR DESCRIPTION
This patch simply updates the READMEs in the hack directories, now that
the self-killing bootkube code is merged, we no longer should instruct
folks to manually kill the process.