### PR TITLE
pkg/asset/templates: Use podIP in kubelet hostname-override

### DIFF
--- a/hack/multi-node/user-data.sample
+++ b/hack/multi-node/user-data.sample
@@ -1,7 +1,5 @@
 #cloud-config
 
-hostname: $public_ipv4
-
 coreos:
   flannel:
     interface: $public_ipv4
@@ -28,6 +26,7 @@ coreos:
       command: start
       content: |
         [Service]
+        EnvironmentFile=/etc/environment
         Environment=KUBELET_ACI=quay.io/aaron_levy/hyperkube
         Environment=KUBELET_VERSION=v1.2.2_runonce.0
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
@@ -37,6 +36,7 @@ coreos:
           --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
           --lock-file=/var/run/lock/kubelet.lock \
           --allow-privileged \
+          --hostname-override=${COREOS_PUBLIC_IPV4} \
           --node-labels=master=true \
           --cluster_dns=10.3.0.10 \
           --cluster_domain=cluster.local

--- a/hack/single-node/user-data.sample
+++ b/hack/single-node/user-data.sample
@@ -1,7 +1,5 @@
 #cloud-config
 
-hostname: $public_ipv4
-
 coreos:
   flannel:
     interface: $public_ipv4
@@ -27,6 +25,7 @@ coreos:
       command: start
       content: |
         [Service]
+        EnvironmentFile=/etc/environment
         Environment=KUBELET_ACI=quay.io/aaron_levy/hyperkube
         Environment=KUBELET_VERSION=v1.2.2_runonce.0
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
@@ -36,6 +35,7 @@ coreos:
           --kubeconfig=/etc/kubernetes/kubeconfig.yaml \
           --lock-file=/var/run/lock/kubelet.lock \
           --allow-privileged \
+          --hostname-override=${COREOS_PUBLIC_IPV4} \
           --node-labels=master=true \
           --cluster_dns=10.3.0.10 \
           --cluster_domain=cluster.local

--- a/pkg/asset/templates/kubelet.yaml
+++ b/pkg/asset/templates/kubelet.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: kubelet
-        image: quay.io/coreos/hyperkube:v1.2.2_coreos.0
+        image: quay.io/aaron_levy/hyperkube:v1.2.2_runonce.0
         command:
         - /nsenter
         - --target=1
@@ -26,10 +26,16 @@ spec:
         - kubelet
         - --api-servers={{ .APIServers }}
         - --allow-privileged
+        - --hostname-override=$(MY_POD_IP)
         - --cluster-dns=10.3.0.10
         - --cluster-domain=cluster.local
         - --kubeconfig=/etc/kubernetes/kubeconfig.yaml
         - --lock-file=/var/run/lock/kubelet.lock
+        env:
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
This change removes the reliance on the node hostname, which was picked up by the kubelet as the default routeable kubelet hostname. The idea is that it is better to explicitly assign a hostname by flag than to have a dependency on the host node's hostname configuration.

I've tested this against the network booted libvirt VM cluster in [coreos-baremetal #170](https://github.com/coreos/coreos-baremetal/pull/170). I haven't validated with the bootkube Vagrantfiles since I don't have a VirtualBox/VMWare setup.