### PR TITLE
pkg/asset: Update version metadata on manifests

### DIFF
--- a/pkg/asset/templates/kube-apiserver.yaml
+++ b/pkg/asset/templates/kube-apiserver.yaml
@@ -11,7 +11,7 @@ spec:
     metadata:
       labels:
         k8s-app: kube-apiserver
-        version: v1.2.2_coreos.0
+        version: v1.2.4_inotify.3
     spec:
       nodeSelector:
         master: "true"

--- a/pkg/asset/templates/kube-controller-manager.yaml
+++ b/pkg/asset/templates/kube-controller-manager.yaml
@@ -5,13 +5,13 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: kube-controller-manager
-    version: 1.2.2_coreos.0
+    version: v1.2.4_inotify.3
 spec:
   template:
     metadata:
       labels:
         k8s-app: kube-controller-manager
-        version: 1.2.2_coreos.0
+        version: v1.2.4_inotify.3
     spec:
       containers:
       - name: kube-controller-manager

--- a/pkg/asset/templates/kube-proxy.yaml
+++ b/pkg/asset/templates/kube-proxy.yaml
@@ -5,13 +5,13 @@ metadata:
   namespace: kube-system
   labels:
     k8s_app: kube-proxy
-    version: v1.2.2_coreos.0
+    version: v1.2.4_inotify.3
 spec:
   template:
     metadata:
       labels:
         k8s_app: kube-proxy
-        version: v1.2.2_coreos.0
+        version: v1.2.4_inotify.3
     spec:
       hostNetwork: true
       containers:

--- a/pkg/asset/templates/kube-scheduler.yaml
+++ b/pkg/asset/templates/kube-scheduler.yaml
@@ -5,13 +5,13 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: kube-scheduler
-    version: 1.2.2_coreos.0
+    version: v1.2.4_inotify.3
 spec:
   template:
     metadata:
       labels:
         k8s-app: kube-scheduler
-        version: 1.2.2_coreos.0
+        version: v1.2.4_inotify.3
     spec:
       containers:
       - name: kube-scheduler

--- a/pkg/asset/templates/kubelet.yaml
+++ b/pkg/asset/templates/kubelet.yaml
@@ -5,13 +5,13 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: kubelet
-    version: 1.2.2_coreos.0
+    version: v1.2.4_inotify.3
 spec:
   template:
     metadata:
       labels:
         k8s-app: kubelet
-        version: 1.2.2_coreos.0
+        version: v1.2.4_inotify.3
     spec:
       containers:
       - name: kubelet


### PR DESCRIPTION
It also seems some weren't prefixed with `v`, either way, it should be consistent.