### PR TITLE
hack: add quickstart scripts & initial GCE guide

### DIFF
--- a/hack/quickstart/.gitignore
+++ b/hack/quickstart/.gitignore
@@ -1,0 +1,1 @@
+cluster/

--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -2,7 +2,7 @@
 
 ### Launch nodes
 
-To find the latest CoreOS alpha/beta/stable images, please see the (CoreOS GCE Documentation)[https://coreos.com/os/docs/latest/booting-on-google-compute-engine.html]
+To find the latest CoreOS alpha/beta/stable images, please see the [CoreOS GCE Documentation](https://coreos.com/os/docs/latest/booting-on-google-compute-engine.html)
 
 Launch 3 nodes:
 

--- a/hack/quickstart/README.md
+++ b/hack/quickstart/README.md
@@ -1,0 +1,56 @@
+## GCE Quickstart
+
+### Launch nodes
+
+To find the latest CoreOS alpha/beta/stable images, please see the (CoreOS GCE Documentation)[https://coreos.com/os/docs/latest/booting-on-google-compute-engine.html]
+
+Launch 3 nodes:
+
+```
+$ gcloud compute instances create k8s-core1 k8s-core2 k8s-core3 \
+  --image https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-1068-0-0-v20160607 \
+  --zone us-central1-a --machine-type n1-standard-1
+```
+
+Tag the master node, and allow traffic to 443 on that node.
+
+```
+$ gcloud compute instances add-tags k8s-core1 --tags apiserver
+$ gcloud compute firewall-rules create api-443 --target-tags=apiserver --allow tcp:443
+```
+
+### Bootstrap Master
+
+*Replace* `<node-ip>` with the EXTERNAL_IP from output of `gcloud compute instances list k8s-core1`.
+
+```
+$ IDENT=~/.ssh/google_compute_engine ./init-master.sh <node-ip>
+```
+
+After the master bootstrap is complete, you can continue to add worker nodes. Or cluster state can be inspected via kubectl:
+
+```
+$ kubectl --kubeconfig=cluster/auth/kubeconfig get nodes
+```
+
+### Bootstrap Nodes
+
+Get the EXTERNAL_IP from each node you wish to add:
+
+```
+gcloud compute instances list k8s-core2
+gcloud compute instances list k8s-core3
+```
+
+Initialize each worker node by replacing `<node-ip>` with the EXTERNAL_IP from the commands above.
+
+```
+IDENT=~/.ssh/google_compute_engine ./init-worker.sh <node-ip> cluster/auth/kubeconfig
+```
+
+**NOTE:** It can take a few minutes for each node to download all of the required assets / containers.
+ They may not be immediately available, but the state can be inspected with:
+
+```
+$ kubectl --kubeconfig=cluster/auth/kubeconfig get nodes
+```

--- a/hack/quickstart/init-master.sh
+++ b/hack/quickstart/init-master.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+set -euo pipefail
+
+function usage() {
+    echo "USAGE:"
+    echo "$0: <remote-host>"
+    exit 1
+}
+
+function configure_etcd() {
+    [ -f "/etc/systemd/system/etcd2.service.d/10-etcd2.conf" ] || {
+        mkdir -p /etc/systemd/system/etcd2.service.d
+        cat << EOF > /etc/systemd/system/etcd2.service.d/10-etcd2.conf
+[Service]
+Environment="ETCD_NAME=controller"
+Environment="ETCD_INITIAL_CLUSTER=controller=http://${COREOS_PRIVATE_IPV4}:2380"
+Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=http://${COREOS_PRIVATE_IPV4}:2380"
+Environment="ETCD_ADVERTISE_CLIENT_URLS=http://${COREOS_PRIVATE_IPV4}:2379"
+Environment="ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379"
+Environment="ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380"
+EOF
+    }
+}
+
+function configure_flannel() {
+    # Configure Flannel options
+    [ -f "/etc/flannel/options.env" ] || {
+        mkdir -p /etc/flannel
+        echo "FLANNELD_IFACE=${COREOS_PRIVATE_IPV4}" >> /etc/flannel/options.env
+        echo "FLANNELD_ETCD_ENDPOINTS=http://127.0.0.1:2379" >> /etc/flannel/options.env
+    }
+
+    # Make sure options are re-used on reboot
+    local TEMPLATE=/etc/systemd/system/flanneld.service.d/10-symlink.conf.conf
+    [ -f $TEMPLATE ] || {
+        mkdir -p $(dirname $TEMPLATE)
+        echo "[Service]" >> $TEMPLATE
+        echo "ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env" >> $TEMPLATE
+    }
+}
+
+# wait until etcd is available, then configure the flannel pod-network settings.
+function configure_network() {
+    while true; do
+        echo "Waiting for etcd..."
+        /usr/bin/etcdctl cluster-health && break
+        sleep 1
+    done
+    /usr/bin/etcdctl set /coreos.com/network/config '{ "Network": "10.2.0.0/16", "Backend":{"Type":"vxlan"}}'
+}
+
+# Initialize a Master node
+function init_master_node() {
+    systemctl daemon-reload
+    systemctl stop update-engine; systemctl mask update-engine
+
+    # Start etcd and configure network settings
+    configure_etcd
+    configure_flannel
+    systemctl enable etcd2; sudo systemctl start etcd2
+    configure_network
+
+    # Start flannel then kubelet
+    systemctl enable flanneld; sudo systemctl start flanneld
+    systemctl enable kubelet; sudo systemctl start kubelet
+
+    # Render cluster assets
+    /usr/bin/rkt run \
+        --volume home,kind=host,source=/home/core \
+        --mount volume=home,target=/core \
+        --trust-keys-from-https --net=host ${BOOTKUBE_REPO}:${BOOTKUBE_VERSION} --exec \
+        /bootkube -- render --asset-dir=/core/assets --api-servers=https://${COREOS_PUBLIC_IPV4}:443,https://${COREOS_PRIVATE_IPV4}:443
+
+    # Move the local kubeconfig into expected location
+    chown -R core:core /home/core/assets
+    mkdir -p /etc/kubernetes
+    cp /home/core/assets/auth/kubeconfig /etc/kubernetes/
+
+    # Start bootkube to launch a self-hosted cluster
+    /usr/bin/rkt run \
+        --volume home,kind=host,source=/home/core \
+        --mount volume=home,target=/core \
+        --net=host ${BOOTKUBE_REPO}:${BOOTKUBE_VERSION} --exec \
+        /bootkube -- start --asset-dir=/core/assets
+}
+
+[ "$#" == 1 ] || usage
+
+REMOTE_HOST=$1
+REMOTE_PORT=${REMOTE_PORT:-22}
+CLUSTER_DIR=${CLUSTER_DIR:-cluster}
+IDENT=${IDENT:-${HOME}/.ssh/id_rsa}
+
+BOOTKUBE_REPO=quay.io/coreos/bootkube
+BOOTKUBE_VERSION=v0.1.0
+
+[ -d "${CLUSTER_DIR}" ] && {
+    echo "Error: CLUSTER_DIR=${CLUSTER_DIR} already exists"
+    exit 1
+}
+
+# This script can execute on a remote host by copying itself + kubelet service unit to remote host.
+# After assets are available on the remote host, the script will execute itself in "local" mode.
+if [ "${REMOTE_HOST}" != "local" ]; then
+    # Set up the kubelet.service on remote host
+    scp -i ${IDENT} -P ${REMOTE_PORT} kubelet.master core@${REMOTE_HOST}:/home/core/kubelet.master
+    ssh -i ${IDENT} -p ${REMOTE_PORT} core@${REMOTE_HOST} "sudo mv /home/core/kubelet.master /etc/systemd/system/kubelet.service"
+
+    # Copy self to remote host so script can be executed in "local" mode
+    scp -i ${IDENT} -P ${REMOTE_PORT} ${BASH_SOURCE[0]} core@${REMOTE_HOST}:/home/core/init-master.sh
+    ssh -i ${IDENT} -p ${REMOTE_PORT} core@${REMOTE_HOST} "sudo /home/core/init-master.sh local"
+
+    # Copy assets from remote host to a local directory. These can be used to launch additional nodes & contain TLS assets
+    mkdir ${CLUSTER_DIR}
+    scp -q -i ${IDENT} -P ${REMOTE_PORT} -r core@${REMOTE_HOST}:/home/core/assets/* ${CLUSTER_DIR}
+
+    # Cleanup
+    ssh -i ${IDENT} -p ${REMOTE_PORT} core@${REMOTE_HOST} "rm -rf /home/core/assets && rm -rf /home/core/init-master.sh"
+
+    echo "Cluster assets copied to ${CLUSTER_DIR}"
+    echo
+    echo "Bootstrap complete. Access your kubernetes cluster using:"
+    echo "kubectl --kubeconfig=${CLUSTER_DIR}/auth/kubeconfig get nodes"
+    echo
+    echo "Additional nodes can be added to the cluster using:"
+    echo "./init-worker.sh <node-ip> ${CLUSTER_DIR}/auth/kubeconfig"
+    echo
+
+# Execute this script locally on the machine, assumes a kubelet.service file has already been placed on host.
+elif [ "$1" == "local" ]; then
+    init_master_node
+fi

--- a/hack/quickstart/init-worker.sh
+++ b/hack/quickstart/init-worker.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -euo pipefail
+
+function usage() {
+    echo "USAGE:"
+    echo "$0: <remote-host> <kube-config>"
+    exit 1
+}
+
+function configure_flannel() {
+    # Configure Flannel options
+    [ -f "/etc/flannel/options.env" ] || {
+        mkdir -p /etc/flannel
+        echo "FLANNELD_IFACE=${COREOS_PRIVATE_IPV4}" >> /etc/flannel/options.env
+        echo "FLANNELD_ETCD_ENDPOINTS=http://${MASTER}:2379" >> /etc/flannel/options.env
+    }
+
+    # Make sure options are re-used on reboot
+    local TEMPLATE=/etc/systemd/system/flanneld.service.d/10-symlink.conf.conf
+    [ -f $TEMPLATE ] || {
+        mkdir -p $(dirname $TEMPLATE)
+        echo "[Service]" >> $TEMPLATE
+        echo "ExecStartPre=/usr/bin/ln -sf /etc/flannel/options.env /run/flannel/options.env" >> $TEMPLATE
+    }
+}
+
+
+# Initialize a worker node
+function init_worker_node() {
+    configure_flannel
+
+    # Setup kubeconfig
+    mkdir -p /etc/kubernetes
+    cp ${KUBECONFIG} /etc/kubernetes/kubeconfig
+
+    # Start services
+    systemctl daemon-reload
+    systemctl stop update-engine; systemctl mask update-engine
+    systemctl enable flanneld; sudo systemctl start flanneld
+    systemctl enable kubelet; sudo systemctl start kubelet
+}
+
+[ "$#" == 2 ] || usage
+
+REMOTE_HOST=$1
+KUBECONFIG=$2
+REMOTE_PORT=${REMOTE_PORT:-22}
+IDENT=${IDENT:-${HOME}/.ssh/id_rsa}
+
+MASTER="$(awk '/server:/ {print $2}' ${KUBECONFIG} | awk -F/ '{print $3}' | awk -F: '{print $1}')"
+if [ -z "${MASTER}" ]; then
+    echo "Could not extract master host from kubeconfig"
+    exit 1
+fi
+
+# This script can execute on a remote host by copying itself + kubelet service unit to remote host.
+# After assets are available on the remote host, the script will execute itself in "local" mode.
+if [ "${REMOTE_HOST}" != "local" ]; then
+    # Set up the kubelet.service on remote host
+    scp -i ${IDENT} -P ${REMOTE_PORT} kubelet.worker core@${REMOTE_HOST}:/home/core/kubelet.worker
+    ssh -i ${IDENT} -p ${REMOTE_PORT} core@${REMOTE_HOST} "sudo sed 's/{{apiserver}}/${MASTER}/' /home/core/kubelet.worker | sudo tee /etc/systemd/system/kubelet.service > /dev/null"
+
+    # Set up the kubeconfig on remote host
+    scp -i ${IDENT} -P ${REMOTE_PORT} ${KUBECONFIG} core@${REMOTE_HOST}:/home/core/kubeconfig
+
+    # Copy self to remote host so script can be executed in "local" mode
+    scp -i ${IDENT} -P ${REMOTE_PORT} ${BASH_SOURCE[0]} core@${REMOTE_HOST}:/home/core/init-worker.sh
+    ssh -i ${IDENT} -p ${REMOTE_PORT} core@${REMOTE_HOST} "sudo /home/core/init-worker.sh local /home/core/kubeconfig"
+
+    # Cleanup
+    ssh -i ${IDENT} -p ${REMOTE_PORT} core@${REMOTE_HOST} "rm /home/core/init-worker.sh"
+
+    echo
+    echo "Node bootstrap complete. It may take a few minutes for the node to become ready. Access your kubernetes cluster using:"
+    echo "kubectl --kubeconfig=${KUBECONFIG} get nodes"
+    echo
+
+# Execute this script locally on the machine, assumes a kubelet.service file has already been placed on host.
+elif [ "$1" == "local" ]; then
+    init_worker_node
+fi

--- a/hack/quickstart/kubelet.master
+++ b/hack/quickstart/kubelet.master
@@ -1,0 +1,26 @@
+[Unit]
+Requires=docker.service etcd2.service flanneld.service
+After=docker.service etcd2.service flanneld.service
+
+[Service]
+Environment=KUBELET_ACI=quay.io/coreos/hyperkube
+Environment=KUBELET_VERSION=v1.3.0-alpha.5_coreos.0
+EnvironmentFile=/etc/environment
+
+ExecStart=/usr/lib/coreos/kubelet-wrapper \
+  --api-servers=https://${COREOS_PRIVATE_IPV4}:443 \
+  --kubeconfig=/etc/kubernetes/kubeconfig \
+  --lock-file=/var/run/lock/kubelet.lock \
+  --exit-on-lock-contention \
+  --allow-privileged \
+  --hostname-override=${COREOS_PRIVATE_IPV4} \
+  --node-labels=master=true \
+  --minimum-container-ttl-duration=3m0s \
+  --cluster_dns=10.3.0.10 \
+  --cluster_domain=cluster.local
+
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/hack/quickstart/kubelet.worker
+++ b/hack/quickstart/kubelet.worker
@@ -1,0 +1,25 @@
+[Unit]
+Requires=docker.service flanneld.service
+After=docker.service flanneld.service
+
+[Service]
+Environment=KUBELET_ACI=quay.io/coreos/hyperkube
+Environment=KUBELET_VERSION=v1.3.0-alpha.5_coreos.0
+EnvironmentFile=/etc/environment
+
+ExecStart=/usr/lib/coreos/kubelet-wrapper \
+  --api-servers=https://{{apiserver}}:443 \
+  --kubeconfig=/etc/kubernetes/kubeconfig \
+  --lock-file=/var/run/lock/kubelet.lock \
+  --exit-on-lock-contention \
+  --allow-privileged \
+  --hostname-override=${COREOS_PRIVATE_IPV4} \
+  --minimum-container-ttl-duration=3m0s \
+  --cluster_dns=10.3.0.10 \
+  --cluster_domain=cluster.local
+
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The quickstart directory contains generic scripts / kubelet.service files which should work for a CoreOS node launched on various providers.

These scripts currently assume `/etc/environment` has been populated with `$COREOS_PUBLIC_IPV4` and `$COREOS_PRIVATE_IPV4`.

The initial guide in the README describes how to use these scripts on vanilla CoreOS nodes using GCE.

ref: https://github.com/coreos/bootkube/issues/32

/cc @philips @pbx0 @dghubble 