### PR TITLE
hack/single-node: Update bootkube-up to add kubeconfig once

### DIFF
--- a/hack/single-node/bootkube-up
+++ b/hack/single-node/bootkube-up
@@ -10,10 +10,9 @@ fi
 # Render assets
 if [ ! -d "cluster" ]; then
   ../../_output/bin/${local_os}/bootkube render --asset-dir=cluster --api-servers=https://172.17.4.100:443
+  # Add rendered kubeconfig to the node user-data
+  cat user-data.sample > cluster/user-data && sed 's/^/      /' cluster/auth/kubeconfig >> cluster/user-data
 fi
-
-# Add rendered kubeconfig to the node user-data
-cat user-data.sample > cluster/user-data && sed 's/^/      /' cluster/auth/kubeconfig >> cluster/user-data
 
 # Start the VM
 vagrant up


### PR DESCRIPTION
This is to match multi-node. This was causing TLS errors because it
caused the user-data containing the kubeconfig to be updated on every
bootkube-up run, when it should only happen on the first run.